### PR TITLE
add sourcemaps when debug == true

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -136,7 +136,9 @@ module.exports = function(options){
             source_comments: options.source_comments || options.sourceComments || false,
             include_paths: [ sassDir ].concat(options.include_paths || options.includePaths || []),
             image_path: options.image_path || options.imagePath,
-            output_style: options.output_style || options.outputStyle
+            output_style: options.output_style || options.outputStyle,
+            sourceMap: options.debug ? cssPath : false,
+            sourceMapEmbed: options.debug ? true : false
           });
         });
       };


### PR DESCRIPTION
This little modification adds source maps when prop debug is true. Useful for example to use in chrome dev tools.
